### PR TITLE
feat: add @sooniter/rspress-plugin-theme-terminal-blog package (Vibe Kanban)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 # Rspress
 doc_build/
 .rspress/
+
+# Build output
+dist/

--- a/docs/public/netlify.toml
+++ b/docs/public/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/*"
+to = "/404.html"
+status = 404

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -7,8 +7,8 @@ hero:
   actions:
     - theme: brand
       text: 博客文章
-      link: /zh/posts/third-party-cookie
+      link: /posts/third-party-cookie
     - theme: alt
       text: 关于我
-      link: /zh/about
+      link: /about
 ---

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "rspress build",
+    "build:website": "pnpm --filter @sooniter/rspress-plugin-theme-terminal-blog build && rspress build",
     "dev": "rspress dev",
     "preview": "rspress preview"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "rspress preview"
   },
   "dependencies": {
-    "@rspress/core": "^2.0.0-rc.3"
+    "@rspress/core": "^2.0.0-rc.3",
+    "@sooniter/rspress-plugin-theme-terminal-blog": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.8.1",

--- a/packages/rspress-plugin-theme-terminal-blog/package.json
+++ b/packages/rspress-plugin-theme-terminal-blog/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@sooniter/rspress-plugin-theme-terminal-blog",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "peerDependencies": {
+    "@rspress/core": "^2.0.0"
+  },
+  "devDependencies": {
+    "@rspress/core": "^2.0.0-rc.3",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/rspress-plugin-theme-terminal-blog/src/index.ts
+++ b/packages/rspress-plugin-theme-terminal-blog/src/index.ts
@@ -1,0 +1,17 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { RspressPlugin } from '@rspress/core';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export function pluginThemeTerminalBlog(): RspressPlugin {
+  return {
+    name: '@sooniter/rspress-plugin-theme-terminal-blog',
+    config(config) {
+      return {
+        ...config,
+        themeDir: path.join(__dirname, 'theme'),
+      };
+    },
+  };
+}

--- a/packages/rspress-plugin-theme-terminal-blog/src/theme/index.tsx
+++ b/packages/rspress-plugin-theme-terminal-blog/src/theme/index.tsx
@@ -1,0 +1,1 @@
+export * from '@rspress/core/theme-original';

--- a/packages/rspress-plugin-theme-terminal-blog/tsconfig.json
+++ b/packages/rspress-plugin-theme-terminal-blog/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@rspress/core':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.4(@types/react@19.2.7)
+      '@sooniter/rspress-plugin-theme-terminal-blog':
+        specifier: workspace:*
+        version: link:packages/rspress-plugin-theme-terminal-blog
     devDependencies:
       '@types/node':
         specifier: ^22.8.1
@@ -27,6 +30,15 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+
+  packages/rspress-plugin-theme-terminal-blog:
+    devDependencies:
+      '@rspress/core':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.4(@types/react@19.2.7)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
 
 packages:
 
@@ -980,6 +992,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2454,6 +2471,8 @@ snapshots:
   trough@2.2.0: {}
 
   tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { pluginThemeTerminalBlog } from '@sooniter/rspress-plugin-theme-terminal-blog';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
+  plugins: [pluginThemeTerminalBlog()],
   title: 'SoonIter',
   description: 'SoonIter 的个人博客',
   lang: 'zh',


### PR DESCRIPTION
## Summary

This PR creates a new Rspress theme plugin as a pnpm workspace package. The plugin provides a foundation for building a custom terminal-style blog theme.

## Changes Made

- **New package**: `@sooniter/rspress-plugin-theme-terminal-blog` in `packages/rspress-plugin-theme-terminal-blog/`
  - `src/index.ts` - Exports `pluginThemeTerminalBlog()` which uses the `config` hook to set `themeDir`
  - `src/theme/index.tsx` - Re-exports `@rspress/core/theme-original` as the base theme
  - `package.json` - Package configuration with peer dependency on `@rspress/core`
  - `tsconfig.json` - TypeScript configuration for ESM output

- **Workspace setup**: Added `pnpm-workspace.yaml` to enable monorepo structure

- **Integration**: Updated root `rspress.config.ts` to use the new plugin

## Implementation Details

The plugin uses Rspress's `config` hook to override the `themeDir` configuration, pointing it to the plugin's `theme` directory. This allows the plugin to customize or extend the default theme while re-exporting all original theme components.

```typescript
config(config) {
  return {
    ...config,
    themeDir: path.join(__dirname, 'theme'),
  };
}
```

---

This PR was written using [Vibe Kanban](https://vibekanban.com)